### PR TITLE
Fix UI floor order

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## Configuration:
 All configuration actions are available in the [config.lua file](https://github.com/Maximus7474/5M-Elevator/blob/1.0.1/shared/config.lua).
 To add more elevators copy the template and alter the values by respecting the structure, not respecting it will lead to errors and the resource not working properly.
+- The floors will show in the same order as listed in the config file.
 
 Specifications:
 - The `vehicle` & `restricted` fields are not yet active, more documentation will be made available when implemented.

--- a/client/client.lua
+++ b/client/client.lua
@@ -36,17 +36,17 @@ end)
 
 RegisterNUICallback('setNewFloor', function(data, cb)
 
-    if isMoving then return cb(false) end
+    if isMoving then DebugPrint("Player is already moving, cancelling") return cb(false) end
 
     isMoving = true
     DebugPrint('Data received from NUI', json.encode(data))
 
-    local success = Citizen.Await(TP.GoToNewFloor(currentElevator, data.clickedFloor))
+    local success = Citizen.Await(TP.GoToNewFloor(currentElevator, data.floorIndex))
 
-    isMoving = false
     cb(success)
 
-    SetTimeout(250, function ()
+    SetTimeout(success and 250 or 500, function ()
+        isMoving = false
         NUI.ToggleNui(false)
     end)
 end)

--- a/client/client.lua
+++ b/client/client.lua
@@ -36,7 +36,7 @@ end)
 
 RegisterNUICallback('setNewFloor', function(data, cb)
 
-    if isMoving then DebugPrint("Player is already moving, cancelling") return cb(false) end
+    if isMoving then DebugPrint("Player is already moving, cancelling") return cb(nil) end
 
     isMoving = true
     DebugPrint('Data received from NUI', json.encode(data))

--- a/client/modules/teleport.lua
+++ b/client/modules/teleport.lua
@@ -12,7 +12,13 @@ function TP.GoToNewFloor(elevator, newfloor)
     local newfloor = Config.Elevators?[elevator]?.floors?[newfloor]?.position
 
     if elevator == nil or newfloor == nil or newfloor?.xyz == nil then
-        DebugPrint("[^2TP^7] ^1Invalid Parameters^7", {elevator=elevator, newfloor=newfloor})
+        DebugPrint("[^2TP^7] ^1Invalid Parameters^7", elevator)
+        DebugPrint(
+            "^3Elevator Data:^7", Config.Elevators?[elevator] or "^1undefined^7",
+            "^3Floor list:^7", Config.Elevators?[elevator]?.floors or "^1undefined^7",
+            "^3Floor Data^7", Config.Elevators?[elevator]?.floors?[newfloor] or "^1undefined^7",
+            "^3Position^7", Config.Elevators?[elevator]?.floors?[newfloor]?.position or "^1undefined^7"
+        )
         success:resolve(false)
     elseif Config.Options.ScreenFade then
         DebugPrint("[^2TP^7] ^2Valid Parameters^7, Teleporting to", newfloor)

--- a/client/modules/utils.lua
+++ b/client/modules/utils.lua
@@ -2,16 +2,17 @@ local Utils = {}
 
 ---Convert Config file structure to NUI structure
 ---@param floors table
----@return table
+---@return table formattedFloors
 function Utils.FormatFloors(floors)
-    local table = {}
-    for k, v in pairs(floors) do
-        table[#table+1] = {
-            floor = k,
-            label = v.label
+    local formattedFloors = {}
+    for i = 1, #floors do
+        formattedFloors[i] = {
+            index = i,
+            floor = floors[i].floor,
+            label = floors[i].label,
         }
     end
-    return table
+    return formattedFloors
 end
 
 return Utils

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -4,8 +4,8 @@ local resourceName = GetCurrentResourceName()
 
 for elevator, data in pairs(Config.Elevators) do
     Zones[elevator] = {}
-    for k, v in pairs(data.floors) do
-        Zones[elevator][#Zones[elevator]+1] = TARGET.AddSphereZone(v.panel, Config.Options.Label, { floor = k, elevator = elevator }, Config.Options.Icon)
+    for _, v in pairs(data.floors) do
+        Zones[elevator][#Zones[elevator]+1] = TARGET.AddSphereZone(v.panel, Config.Options.Label, { floor = v.floor, elevator = elevator }, Config.Options.Icon)
     end
 end
 

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,7 +1,7 @@
 Config = {}
 
 --[[ Set Debug Mode ]]
-Config.Debug = false
+Config.Debug = true
 Config.DebugZones = false
 
 --[[ Set to false if you do not want to be notified on updates ]]
@@ -42,17 +42,20 @@ Config.Elevators = {
         restricted = false,
         vehicle = false,
         floors = {
-            ["-2"] = {
+            {
+                floor = "-2",
                 label = "Garage Entrance",
                 panel = vector4(-82.5941, -819.1429, 36.0281, 260.1323),
                 position = vector4(-84.2893, -821.5383, 36.0281, 344.3796)
             },
-            ["57"] = {
+            {
+                floor = "57",
                 label = "Interior Garage",
                 panel = vector4(-92.1781, -821.9614, 222.0004, 251.2057),
                 position = vector4(-91.8228, -821.1077, 222.0004, 255.4299)
             },
-            ["65"] = {
+            {
+                floor = "65",
                 label = "Mod Shop",
                 panel = vector4(-73.5848, -809.6722, 285.0000, 163.1215),
                 position = vector4(-71.4348, -810.7918, 285.0000, 159.1122)

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -46,7 +46,11 @@ const App: React.FC< any > = () => {
   const handleButtonClick = (floorIndex: number, clickedFloor: string) => {
     fetchNui<boolean>("setNewFloor", {floorIndex: floorIndex})
       .then((retData) => {
-        if (retData) setCurrentFloor(clickedFloor);
+        if (retData) {
+          setCurrentFloor(clickedFloor)
+        } else if (typeof clickedFloor === "boolean") {
+          setCurrentFloor("ERR")
+        };
       })
       .catch((e) => {
         setCurrentFloor("ERR");

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -6,40 +6,45 @@ import { useNuiEvent } from "../hooks/useNuiEvent";
 import FloorView from "./elements/floor-view";
 import FloorButton from "./elements/floor-button";
 
-// This will set the NUI to visible if we are
-// developing in browser
+interface floorButtons {
+  floor:string,
+  label:string,
+  index:number,
+}
+
 debugData([
   {
     action: "setFloors",
     data: {
       currentFloor: 1,
       floorButtons: [
-        {floor: "-1", label: "Underground 1"},
-        {floor: "0", label: "Lobby"},
-        {floor: "1", label: "First Floor"},
+        {floor: "-1", label: "Underground 1", index: 1},
+        {floor: "0", label: "Lobby", index: 2},
+        {floor: "1", label: "First Floor", index: 3},
       ]
     },
   },
 ]);
+
 debugData([
   {
     action: "setVisible",
-    data: true
-  }
+    data: true,
+  },
 ]);
 
 const App: React.FC< any > = () => {
 
   const [currentFloor, setCurrentFloor] = useState<string>("0");
-  const [floorButtons, setFloorButtons] = useState<{ floor: string; label: string; }[]>([]);
+  const [floorButtons, setFloorButtons] = useState<floorButtons[]>([]);
 
-  useNuiEvent<{ currentFloor: string; floorButtons: { floor: string; label: string; }[] }>('setFloors', (data) => {
+  useNuiEvent<{ currentFloor: string; floorButtons: floorButtons[] }>('setFloors', (data) => {
     setCurrentFloor(data.currentFloor);
     setFloorButtons(data.floorButtons);
   });
 
-  const handleButtonClick = (clickedFloor: string) => {
-    fetchNui<boolean>("setNewFloor", {clickedFloor: clickedFloor})
+  const handleButtonClick = (floorIndex: number, clickedFloor: string) => {
+    fetchNui<boolean>("setNewFloor", {floorIndex: floorIndex})
       .then((retData) => {
         if (retData) setCurrentFloor(clickedFloor);
       })
@@ -53,9 +58,11 @@ const App: React.FC< any > = () => {
       <div className="elevator-panel">
         <FloorView floor={currentFloor} />
         <div className="button-grid">
-          {floorButtons.map(({ floor, label }) => (
-            <FloorButton key={floor} floor={floor} label={label} onClick={() => handleButtonClick(floor)} />
-          ))}
+          {
+            floorButtons.map(({ floor, label, index }) => (
+              <FloorButton key={floor} floor={floor} label={label} onClick={() => handleButtonClick(index, floor)} />
+            ))
+          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Pull Request Description

Fixes the issue where the floors wouldn't show in the correct order in the UI

## Major Changes

- Changed the structure of the `Config.Elevators`
  - Changed from string indexes to numeric indexes
- Adapted handling of the new floor indexing

## Modifications done
- [ ] 🍃 New Feature
- [x] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
