### PR TITLE
refactor(5M-Elevator): SphereZone radius in config

### DIFF
--- a/client/modules/targets/ox_target.lua
+++ b/client/modules/targets/ox_target.lua
@@ -4,7 +4,7 @@ return {
     AddSphereZone = function (coords, label, data, icon)
         return exports.ox_target:addSphereZone({
             coords = coords,
-            radius = 2.0,
+            radius = Config.Options.Distance,
             debug = Config.DebugZones,
             options = {{
                 label = label,


### PR DESCRIPTION
### Pull Request Description

/client/modules/target/ox_target.lua


## Major Changes

I think that is better to set the radius of the Sphere in the module for ox_target  form the config file, is better to make an easier debugg and know the real radius of the interaction

## Modifications done
- [ ] 🍃 New Feature
- [X ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
