### PR TITLE
Fixes

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -45,8 +45,12 @@ RegisterNUICallback('setNewFloor', function(data, cb)
 
     cb(success)
 
-    SetTimeout(success and 250 or 500, function ()
+    if Config.Options.CloseUI then
+        SetTimeout(success and 250 or 500, function ()
+            isMoving = false
+            NUI.ToggleNui(false)
+        end)
+    else
         isMoving = false
-        NUI.ToggleNui(false)
-    end)
+    end
 end)

--- a/client/modules/targets/ox_target.lua
+++ b/client/modules/targets/ox_target.lua
@@ -16,6 +16,6 @@ return {
         })
     end,
     RemoveZone = function (id)
-        exports['qb-target']:RemoveZone(id)
+        exports.ox_target:removeZone(id)
     end,
 }

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,7 +1,7 @@
 Config = {}
 
 --[[ Set Debug Mode ]]
-Config.Debug = true
+Config.Debug = false
 Config.DebugZones = false
 
 --[[ Set to false if you do not want to be notified on updates ]]
@@ -29,6 +29,9 @@ Config.Options = {
     --[[ Set the Text UI & Key to use ]]
     TextUI = "Press [%s] to open elevator panel",
     Key = { id = 38, name = "E" },
+
+    --[[ Set to true if you don't want the UI to close automatically ]]
+    CloseUI = true,
 
     --[[ if false teleports immediatly ]]
     ScreenFade = true,


### PR DESCRIPTION
### Pull Request Description

Stupid mistake in the ox_target module for removing a zone, even if this wouldn't cause a massive error amount because not many servers would restart the resource during use.
Added an option to auto close or not the UI when changing floor.

## Modifications done
- [ ] 🍃 New Feature
- [x] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
