### PR TITLE
fixed autoclose UI

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -54,7 +54,7 @@ Events:ElevatorCallback('elevator:internal:setnewfloor', function (source, eleva
     return {
         restricted = data.restricted,
         floors = data.floors,
-        access = success and 'authorized' or 'denied',
+        success = success,
     }
 end)
 


### PR DESCRIPTION
### Pull Request Description

The client callback "SetNewFloor" (client/client.lua) expects the server callback "elevator:internal:setnewfloor" (server/server.lua) to return a success parameter; instead, it returns an access parameter, which resulted in the UI not closing automatically with the flag set in the config.

## Modifications done
- [ ] 🍃 New Feature
- [ ] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
